### PR TITLE
Removed duplicate const.

### DIFF
--- a/src/dtan.c
+++ b/src/dtan.c
@@ -16,8 +16,6 @@ DtanObject DtanNew(const char* displayString, DtanCharset charset) {
     return dtan_object;
 }
 
-#include<stdio.h>
-
 int DtanUpdateStatus(DtanObject* dtanObject) {
     const DtanPair* current_pair = &(dtanObject->interval[dtanObject->status.current_index]);
     double increment_alpha_size = (double)ALPHA_MAX_SIZE / (double)current_pair->time;

--- a/src/dtan.c
+++ b/src/dtan.c
@@ -30,11 +30,11 @@ int DtanUpdateStatus(DtanObject* dtanObject) {
         }
     }
 
-    unsigned int length = sizeof(dtanObject->interval) / sizeof(dtanObject->interval[0]);
     unsigned int max_time = current_pair->time;
     if (dtanObject->status.current_time >= max_time) {
         dtanObject->status.current_index++;
         dtanObject->status.current_time = 0;
+        unsigned int length = sizeof(dtanObject->interval) / sizeof(dtanObject->interval[0]);
         if( !(dtanObject->status.current_index < length) ) return 0;
     }
     dtanObject->status.current_time++;

--- a/src/dtan.h
+++ b/src/dtan.h
@@ -24,7 +24,7 @@ struct dtan_pair {
     DtanFade fade;
 } typedef DtanPair;
 
-typedef const DtanPair DtanInterval[3];
+typedef DtanPair DtanInterval[3];
 
 struct dtan_status {
     unsigned char alpha;


### PR DESCRIPTION
Fixed a warning that occurred in CL and MSBuild.

```
dtan.h(38): warning C4114: same type qualifier used more than once
```